### PR TITLE
Allow interceptors to redirect with replaceState

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -67,8 +67,9 @@ class Router {
 
   processRedirect(context) {
     var uri = context.response.redirectTo;
+    var shouldReplace = Boolean(context.response.shouldReplace);
     this.rootContext.addRedirect(uri);
-    this.navigateTo(uri);
+    this.navigateTo(uri, shouldReplace);
   }
 
   navigateTo() {


### PR DESCRIPTION
This change allows interceptors to set a `shouldReplace` property on the response object, signalling that the redirect should be performed with replaceState rather than pushState.

```js
router.use(function(request, response, next) {
  try {
    return next();
  } finally {
    if (request.uri != '/redirected')
      response.redirectTo = '/redirected';
      response.shouldReplace = true;
  }
});
```

If there's already a way to achieve this feel free to reject this PR and point me in the right direction.
